### PR TITLE
Remove schedule of biograkn-nightly workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,14 +232,6 @@ workflows:
             - build
 
   biograkn-nightly:
-    triggers:
-      - schedule:
-          cron: "0 19 * * *" # UTC
-          filters:
-            branches:
-              only:
-                - master
- 
     jobs:
       - assembly-linux-all:
           filters:


### PR DESCRIPTION
Removing the schedule of biograkn-nightly workflow because it is triggered everyday as per the cron. Where as we would desire it to run only once per commit to master.

closes: #58 