### PR TITLE
Unlimited memory for Bazel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       #      - run: bazel run @graknlabs_build_tools//checkstyle:test-coverage
-      - run: bazel --host_jvm_args=-Xmx16g build //...
+      - run: bazel build //...
 
   test-assembly-linux-mock:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?

Fix CI
Previously, it failed with `MemoryError` as JVM was configured to have 16 GB as upper limit. Investigating `free -h` on CircleCI machine showed that only 8 GB is available, therefore we'll resort to default settings.

## What are the changes implemented in this PR?

Allow `bazel` to use unlimited memory