### PR TITLE
Remove dependency on @graknlabs_grakn_core//api:api

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -36,7 +36,7 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/graknlabs/client-java",
-        commit = "7c2799c07cb797a716084f5d3b1277f0d760493f" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
+        commit = "652c329a05e7e583bab97dee9565156baf03f2c8" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grakn_core
     )
 
 def graknlabs_client_python():

--- a/migrator/AssembleAllTest.java
+++ b/migrator/AssembleAllTest.java
@@ -1,7 +1,7 @@
 package grakn.biograkn.migrator;
 
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.Numeric;
+import grakn.client.answer.Numeric;
 import graql.lang.Graql;
 import graql.lang.query.GraqlCompute;
 import org.junit.Before;

--- a/migrator/AssembleMockTest.java
+++ b/migrator/AssembleMockTest.java
@@ -1,7 +1,7 @@
 package grakn.biograkn.migrator;
 
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.Numeric;
+import grakn.client.answer.Numeric;
 import graql.lang.Graql;
 import graql.lang.query.GraqlCompute;
 import org.junit.Before;

--- a/migrator/BUILD
+++ b/migrator/BUILD
@@ -10,7 +10,6 @@ java_library(
         "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//common:common",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//api:api",
 
         "//dependencies/maven/artifacts/org/apache/poi:poi-ooxml",
         "//dependencies/maven/artifacts/org/apache/commons:commons-csv",
@@ -61,7 +60,6 @@ java_test(
         "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//common:common",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//api:api",
     ],
   )
 
@@ -75,7 +73,6 @@ java_test(
         "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//common:common",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//api:api",
     ],
   )
 

--- a/precisionmedicine/migrator/BUILD
+++ b/precisionmedicine/migrator/BUILD
@@ -9,7 +9,6 @@ java_library(
         "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//common:common",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//api:api",
 
         "//dependencies/maven/artifacts/org/apache/poi:poi-ooxml",
         "//dependencies/maven/artifacts/org/apache/commons:commons-csv",

--- a/precisionmedicine/migrator/clinicaltrial/ClinicalTrial.java
+++ b/precisionmedicine/migrator/clinicaltrial/ClinicalTrial.java
@@ -3,7 +3,7 @@ package grakn.biograkn.precisionmedicine.migrator.clinicaltrial;
 
 import grakn.biograkn.utils.Utils;
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
 import static graql.lang.Graql.var;

--- a/precisionmedicine/migrator/clinicaltrialrelationships/ClinicalTrialRelationship.java
+++ b/precisionmedicine/migrator/clinicaltrialrelationships/ClinicalTrialRelationship.java
@@ -1,7 +1,7 @@
 package grakn.biograkn.precisionmedicine.migrator.clinicaltrialrelationships;
 
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 import graql.lang.Graql;
 import graql.lang.query.GraqlGet;
 import graql.lang.query.GraqlInsert;

--- a/precisionmedicine/migrator/disease/Disease.java
+++ b/precisionmedicine/migrator/disease/Disease.java
@@ -5,7 +5,7 @@ import grakn.client.GraknClient;
 import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
 import graql.lang.query.GraqlGet;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 
 import static graql.lang.Graql.var;
 

--- a/precisionmedicine/migrator/drug/Drug.java
+++ b/precisionmedicine/migrator/drug/Drug.java
@@ -2,7 +2,7 @@ package grakn.biograkn.precisionmedicine.migrator.drug;
 
 import grakn.biograkn.utils.Utils;
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 import graql.lang.Graql;
 import graql.lang.query.GraqlGet;
 import graql.lang.query.GraqlInsert;

--- a/precisionmedicine/migrator/drugdisease/DrugDiseaseAssociation.java
+++ b/precisionmedicine/migrator/drugdisease/DrugDiseaseAssociation.java
@@ -4,7 +4,7 @@ import grakn.biograkn.utils.Utils;
 import grakn.client.GraknClient;
 import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 import static graql.lang.Graql.var;
 
 import grakn.biograkn.precisionmedicine.migrator.disease.Disease;

--- a/precisionmedicine/migrator/gene/Gene.java
+++ b/precisionmedicine/migrator/gene/Gene.java
@@ -1,7 +1,7 @@
 package grakn.biograkn.precisionmedicine.migrator.gene;
 
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 import graql.lang.Graql;
 import graql.lang.query.GraqlGet;
 import graql.lang.query.GraqlInsert;

--- a/precisionmedicine/migrator/genedisease/GeneDiseaseAssociation.java
+++ b/precisionmedicine/migrator/genedisease/GeneDiseaseAssociation.java
@@ -4,7 +4,7 @@ import grakn.biograkn.utils.Utils;
 import grakn.client.GraknClient;import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
 import graql.lang.query.GraqlGet;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 
 import static graql.lang.Graql.var;
 

--- a/precisionmedicine/migrator/variant/Variant.java
+++ b/precisionmedicine/migrator/variant/Variant.java
@@ -3,7 +3,7 @@ package grakn.biograkn.precisionmedicine.migrator.variant;
 import grakn.biograkn.utils.Utils;
 import grakn.client.GraknClient;import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 
 import static graql.lang.Graql.var;
 

--- a/precisionmedicine/migrator/variantdisease/VariantDiseaseAssociation.java
+++ b/precisionmedicine/migrator/variantdisease/VariantDiseaseAssociation.java
@@ -3,7 +3,7 @@ package grakn.biograkn.precisionmedicine.migrator.variantdisease;
 import grakn.biograkn.utils.Utils;
 import grakn.client.GraknClient;import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 
 import static graql.lang.Graql.var;
 

--- a/textmining/migrator/BUILD
+++ b/textmining/migrator/BUILD
@@ -9,7 +9,6 @@ java_library(
         "@graknlabs_grakn_core//concept:concept",
         "@graknlabs_grakn_core//common:common",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_grakn_core//api:api",
 
         "//dependencies/maven/artifacts/org/apache/poi:poi-ooxml",
         "//dependencies/maven/artifacts/org/apache/commons:commons-csv",

--- a/textmining/migrator/corenlp/CoreNLP.java
+++ b/textmining/migrator/corenlp/CoreNLP.java
@@ -11,7 +11,7 @@ import edu.stanford.nlp.pipeline.StanfordCoreNLP;
 import edu.stanford.nlp.sequences.SeqClassifierFlags;
 import edu.stanford.nlp.util.StringUtils;
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 import graql.lang.Graql;
 import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlGet;

--- a/textmining/migrator/pubmedarticle/PubmedArticle.java
+++ b/textmining/migrator/pubmedarticle/PubmedArticle.java
@@ -3,7 +3,7 @@ package grakn.biograkn.textmining.migrator.pubmedarticle;
 
 
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
 import static graql.lang.Graql.var;

--- a/utils/Utils.java
+++ b/utils/Utils.java
@@ -1,7 +1,7 @@
 package grakn.biograkn.utils;
 
 import grakn.client.GraknClient;
-import grakn.core.concept.answer.ConceptMap;
+import grakn.client.answer.ConceptMap;
 import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
 import graql.lang.query.GraqlQuery;


### PR DESCRIPTION
## What is the goal of this PR?

Remove dependency on library that is no longer present in Grakn Core

## What are the changes implemented in this PR?

* Remove `@graknlabs_grakn_core//api:api` from all `deps`
* Use `Numeric` and `ConceptMap` from `grakn.client.answer` package